### PR TITLE
Add some CLI command stubs

### DIFF
--- a/src/root_subvol_snapshot/cli.py
+++ b/src/root_subvol_snapshot/cli.py
@@ -3,12 +3,20 @@ Provide CLI
 
 This module provides the CLI to enter the program.
 """
+import sys
 import typing as t
 from pathlib import Path
 
 import typer
 
 app = typer.Typer()
+
+
+def main() -> None:
+    if len(sys.argv) == 1:
+        snapshot()
+    else:
+        app()
 
 
 @app.command()
@@ -27,4 +35,4 @@ def snapshot(device: t.Annotated[t.Optional[Path], typer.Argument()] = None) -> 
 
 
 if __name__ == "__main__":
-    app()
+    main()

--- a/src/root_subvol_snapshot/cli.py
+++ b/src/root_subvol_snapshot/cli.py
@@ -21,5 +21,10 @@ def close(device: t.Annotated[t.Optional[Path], typer.Argument()] = None) -> Non
     typer.echo(f"Closing {device}...")
 
 
+@app.command()
+def snapshot(device: t.Annotated[t.Optional[Path], typer.Argument()] = None) -> None:
+    typer.echo("Making a snapshot of the root subvolume...")
+
+
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,3 +32,9 @@ def test_close_with_argument(tmp_path):
     result = runner.invoke(app, ["close", str(tmp_path)])
     assert result.exit_code == 0
     assert result.output.endswith(f"{tmp_path}...\n")
+
+
+def test_snapshot():
+    result = runner.invoke(app, ["snapshot"])
+    assert result.exit_code == 0
+    assert result.output.startswith("Making a snapshot of the root subvolume...")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
-from root_subvol_snapshot.cli import app
+import sys
+
+from root_subvol_snapshot.cli import app, main
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -8,6 +10,13 @@ def test_cli():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "Show this message and exit." in result.output
+
+
+def test_cli_without_args_snapshots(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "argv", [sys.argv[0]])
+    main()
+    captured = capsys.readouterr()
+    assert captured.out == "Making a snapshot of the root subvolume...\n"
 
 
 def test_open():


### PR DESCRIPTION
In order to test the automatic release generation, some more reasons to increase the version number have to be found. Adding stubs of commands already planned to support is a good idea.

Thus, this change set provides a `snapshot` command and a test to ensure that this command is triggered if the program is called without arguments.